### PR TITLE
Remove global variables usage from base channel. - Closes #53

### DIFF
--- a/packages/lisk-core/src/channels/base.js
+++ b/packages/lisk-core/src/channels/base.js
@@ -27,6 +27,9 @@ module.exports = class Base {
 		actions.forEach((action) =>
 			this.actionsList.push(new Action(`${moduleAlias}:${action}`, null, null)),
 		);
+
+		this.eventsList = Object.freeze(this.eventList);
+		this.actionsList = Object.freeze(this.actionsList);
 	}
 
 	getActions() {

--- a/packages/lisk-core/src/channels/base.js
+++ b/packages/lisk-core/src/channels/base.js
@@ -7,37 +7,51 @@ const internalEvents = [
 	'loading:finished',
 ];
 
+/**
+ * Private object is used to store private variables of the instances.
+ * Since variables will be stored with the instance reference (this),
+ * this approach is an acceptable way to store private variables
+ * and easy to refactor in future.
+ *
+ * See: http://voidcanvas.com/es6-private-variables/
+ */
+const private = {
+	eventList: new WeakMap(),
+	actionList: new WeakMap(),
+}
+
 module.exports = class Base {
 	constructor(moduleAlias, events, actions, options = {}) {
 		this.moduleAlias = moduleAlias;
 		this.options = options;
-		this.eventsList = [];
-		this.actionsList = [];
+
+		const eventList = [];
+		const actionList = [];
 
 		events.forEach((event) =>
-			this.eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
+			eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
 		);
 
 		if (!options.skipInternalEvents) {
 			internalEvents.forEach((event) =>
-				this.eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
+				eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
 			);
 		}
 
 		actions.forEach((action) =>
-			this.actionsList.push(new Action(`${moduleAlias}:${action}`, null, null)),
+			actionList.push(new Action(`${moduleAlias}:${action}`, null, null)),
 		);
 
-		this.eventsList = Object.freeze(this.eventList);
-		this.actionsList = Object.freeze(this.actionsList);
+		private.eventList.set(this, Object.freeze(eventList));
+		private.actionList.set(this, Object.freeze(actionList));
 	}
 
 	getActions() {
-		return this.actionsList;
+		return private.actionList.get(this);
 	}
 
 	getEvents() {
-		return this.eventsList;
+		return private.eventList.get(this);
 	}
 
 	// eslint-disable-next-line class-methods-use-this

--- a/packages/lisk-core/src/channels/base.js
+++ b/packages/lisk-core/src/channels/base.js
@@ -1,9 +1,6 @@
 const Event = require('../event');
 const Action = require('../action');
 
-const eventsList = new WeakMap();
-const actionsList = new WeakMap();
-
 const internalEvents = [
 	'registeredToBus',
 	'loading:started',
@@ -14,25 +11,30 @@ module.exports = class Base {
 	constructor(moduleAlias, events, actions, options = {}) {
 		this.moduleAlias = moduleAlias;
 		this.options = options;
+		this.eventsList = [];
+		this.actionsList = [];
 
-		eventsList.set(
-			this,
-			(options.skipInternalEvents ? events : internalEvents.concat(events)).map(
-				e => new Event(`${this.moduleAlias}:${e}`, null, null),
-			),
+		events.forEach((event) =>
+			this.eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
 		);
-		actionsList.set(
-			this,
-			actions.map(a => new Action(`${this.moduleAlias}:${a}`, null, null)),
+
+		if (!options.skipInternalEvents) {
+			internalEvents.forEach((event) =>
+				this.eventList.push(new Event(`${moduleAlias}:${event}`, null, null)),
+			);
+		}
+
+		actions.forEach((action) =>
+			this.actionsList.push(new Action(`${moduleAlias}:${action}`, null, null)),
 		);
 	}
 
 	getActions() {
-		return actionsList.get(this);
+		return this.actionsList;
 	}
 
 	getEvents() {
-		return eventsList.get(this);
+		return this.eventsList;
 	}
 
 	// eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## What was the problem?
we had eventList and actionList global variables defined as WeakMap and they were being used in Base channel class.

## How did I fix it?
I removed global variables and moved events and actions list into class instance.

## Review checklist
The PR resolves #53 